### PR TITLE
feat(lean-diff-types): take type diff from `company-coq`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Key Bindings and Commands
 | <kbd>C-c C-d</kbd> | show a searchable list of definitions (`helm-lean-definitions`)                 |
 | <kbd>C-c C-g</kbd> | toggle showing current tactic proof goal (`lean-toggle-show-goal`)              |
 | <kbd>C-c C-n</kbd> | toggle showing next error in dedicated buffer (`lean-toggle-next-error`)        |
+| <kbd>C-c C-t</kbd> | apply `diff` to the expected / actual type in error messages (`lean-diff-types`)             |
 | <kbd>C-c C-b</kbd> | toggle showing output in inline boxes (`lean-message-boxes-toggle`)             |
 | <kbd>C-c C-r</kbd> | restart the lean server (`lean-server-restart`)                                 |
 | <kbd>C-c C-s</kbd> | switch to a different Lean version via [elan](https://github.com/Kha/elan) (`lean-server-switch-version`) |

--- a/lean-diff-types.el
+++ b/lean-diff-types.el
@@ -1,0 +1,77 @@
+
+(defmacro lean-with-current-buffer-maybe (bufname &rest body)
+  "If BUFNAME is a live buffer, run BODY in it."
+  (declare (indent defun)
+           (debug t))
+  `(-when-let* ((bufname ,bufname)
+                (buf (get-buffer bufname)))
+     (with-current-buffer buf
+       ,@body)))
+
+(defun lean--make-diff-temp-buffer (bufname string prefix)
+  "Insert STRING into BUFNAME, with optional PREFIX."
+  (with-current-buffer (get-buffer-create bufname)
+    (let ((inhibit-read-only t))
+      (erase-buffer)
+      (when prefix (insert prefix))
+      (insert string)
+      (newline))
+    (current-buffer)))
+
+(defun lean-diff-strings (s1 s2 prefix diff-buffer-name context)
+  "Compare S1 and S2, with PREFIX.
+Use DIFF-BUFFER-NAME to name newly created buffers.  Display CONTEXT lines
+of context around differences."
+  (let ((same-window-buffer-names '("*Diff*"))
+        (b1 (lean--make-diff-temp-buffer (format "*lean-%s-A*" diff-buffer-name) s1 prefix))
+        (b2 (lean--make-diff-temp-buffer (format "*lean-%s-B*" diff-buffer-name) s2 prefix)))
+    (set-window-dedicated-p (selected-window) nil)
+    (lean-with-current-buffer-maybe diff-buffer-name
+      (kill-buffer))
+    (unwind-protect
+        (diff b1 b2 `(,(format "--unified=%d" context) "--minimal" "--ignore-all-space") 'noasync)
+      (kill-buffer b1)
+      (kill-buffer b2))
+    (lean-with-current-buffer-maybe "*Diff*"
+      (diff-refine-hunk)
+      (rename-buffer diff-buffer-name)
+      (save-excursion
+        (goto-char (point-min))
+        (let ((inhibit-read-only t))
+          (when (re-search-forward "^@@" nil t)
+            (delete-region (point-min) (match-beginning 0)))
+          (while (re-search-forward " *\n *\n\\( *\n\\)+" nil t)
+            ;; Remove spurious spacing added to prevent diff from mixing terms
+            (replace-match "\n" t t)))))))
+
+(defun lean-not-is-expected (x)
+  (not (equal "but is expected to have type" x)))
+(defun lean-not-is-actual (x)
+  (not (equal "has type" x)))
+
+(defun lean-diff-types ()
+  (interactive)
+  (let* ((errs (with-current-buffer (get-buffer lean-next-error-buffer-name)
+                  (buffer-substring-no-properties (point-min) (point-max))))
+         (lns (split-string errs "\n"))
+         (msg (seq-take-while 'lean-not-is-actual lns))
+         (types (seq-drop (seq-drop-while 'lean-not-is-actual lns) 1 ))
+         (expected (seq-take-while (lambda (x) (not (string-empty-p x)))
+                                   (seq-drop (seq-drop-while 'lean-not-is-expected types) 1)))
+         (actual (seq-take-while 'lean-not-is-expected types)))
+    (unless (null expected)
+      (save-selected-window
+        (with-current-buffer (get-buffer-create "*lean-diff*")
+          (pop-to-buffer
+           ;; (switch-to-buffer-other-window
+           (current-buffer) '())
+          (lean-diff-strings (mapconcat 'identity actual "\n")
+                             (mapconcat 'identity expected "\n")
+                             "type: " "*lean-diff*" 5)
+          (with-current-buffer (get-buffer-create "*lean-diff*")
+            (let ((buffer-read-only nil))
+              (save-excursion
+                (insert (mapconcat 'identity msg "\n" ))
+                (insert "\n")))))))))
+
+(provide 'lean-diff-types)

--- a/lean-mode.el
+++ b/lean-mode.el
@@ -42,6 +42,7 @@
 (require 'lean-info)
 (require 'lean-hole)
 (require 'lean-type)
+(require 'lean-diff-types)
 (require 'lean-message-boxes)
 (require 'lean-right-click)
 (require 'lean-dev)
@@ -106,6 +107,7 @@
   (local-set-key lean-keybinding-leanpkg-configure         #'lean-leanpkg-configure)
   (local-set-key lean-keybinding-leanpkg-build             #'lean-leanpkg-build)
   (local-set-key lean-keybinding-leanpkg-test              #'lean-leanpkg-test)
+  (local-set-key lean-keybinding-diff-type                 #'lean-diff-type)
   ;; This only works as a mouse binding due to the event, so it is not abstracted
   ;; to avoid user confusion.
   (local-set-key (kbd "<mouse-3>")                         #'lean-right-click-show-menu)

--- a/lean-settings.el
+++ b/lean-settings.el
@@ -130,4 +130,7 @@ false (nil)."
 (defcustom lean-keybinding-leanpkg-test (kbd "C-c C-p C-t")
   "Lean Keybinding for lean-leanpkg-test"
   :group 'lean-keybinding :type 'key-sequence)
+(defcustom lean-keybinding-diff-type (kbd "C-c C-t")
+  "Lean Keybinding for lean-diff-type"
+  :group 'lean-keybinding :type 'key-sequence)
 (provide 'lean-settings)


### PR DESCRIPTION
Apply `diff` to expected type / actual type in error messages.

Issue: a large part of the code comes from `company-coq` which has a GPL license. I am unsure how to reconcile this with Apache.