### PR TITLE
fix(lean-eri): remove runtime require of cl

### DIFF
--- a/lean-eri.el
+++ b/lean-eri.el
@@ -6,8 +6,6 @@
 
 ;;; Code:
 
-(require 'cl)
-
 (defun lean-eri-current-line-length nil
   "Calculate length of current line."
   (- (line-end-position) (line-beginning-position)))


### PR DESCRIPTION
The 'cl' package has been deprecated in favor of `cl-lib` [0], and
requiring it during runtime results in a warning.

[0]: https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=1d8b5bc8dd543ada2f3c46436e43ea27faa3cd0e