### PR TITLE
Allow displaying Lean goal in another frame

### DIFF
--- a/lean-info.el
+++ b/lean-info.el
@@ -54,7 +54,7 @@
   "Checks whether the given info buffer should show info for the current buffer"
   (and
    ;; info buffer visible
-   (get-buffer-window buffer)
+   (get-buffer-window buffer 'visible)
    ;; current window of current buffer is selected (i.e., in focus)
    (eq (current-buffer) (window-buffer))))
 


### PR DESCRIPTION
### Description
This change allows displaying the Lean goal in another window if desired.

### Problem

Before this change, if the `*Lean Goal*` buffer is in another frame, it won't display the Lean goal. This makes it hard to use `lean-mode` with `frames-only-mode`. `lean-mode` checks whether the `*Lean Goal*` buffer is visible in order (I assume) to avoid wasting time updating a buffer that's not visible. However, before this change, the `*Lean Goal*` buffer needed to be in the focused frame in order to authorize updates.

### Proposed solution

Instead of checking whether the `*Lean Goal*` buffer is active in the current frame, check whether it's active in any visible frame.

### Alternative solutions


The other options are presented by the `ALL-FRAMES` argument to `(get-buffer-window)`:

> BUFFER-OR-NAME may be a buffer or a buffer name and defaults to
the current buffer.
>
> The optional argument ALL-FRAMES specifies the frames to consider:
>
> - t means consider all windows on all existing frames.
>
> - visible means consider all windows on all visible frames.
>
> - 0 (the number zero) means consider all windows on all visible
    and iconified frames.
>
> - A frame means consider all windows on that frame only.

"Iconified" means an icon of the frame is visible rather than the actual frame contents, so that's not desired. An alternative could be using `t` (all frames), but that defeats the optimization. It might be a good idea for some use case I haven't thought of. `'visible` seems like a reasonable compromise in any case.

### Downsides

I don't see any. It seems to work with or without `frames-only-mode`.