### PR TITLE
Increase memory limit for lean from 1G to 4G

### DIFF
--- a/lean-settings.el
+++ b/lean-settings.el
@@ -35,7 +35,7 @@
   :group 'lean
   :type 'string)
 
-(defcustom lean-memory-limit 1024
+(defcustom lean-memory-limit 4096
   "Memory limit for lean process in megabytes"
   :group 'lean
   :type 'number)


### PR DESCRIPTION
The current default (1G) is too low, especially when editing files in
large projects like mathlib, so increase to the more reasonable 4G.