### PR TITLE
Change the requires-pattern in helm-lean

### DIFF
--- a/helm-lean.el
+++ b/helm-lean.el
@@ -49,7 +49,7 @@
   (interactive)
   (require 'helm)
   (helm :sources (helm-build-sync-source "helm-source-lean-definitions"
-                   :requires-pattern t
+                   :requires-pattern 1
                    :candidates 'helm-lean-definitions-candidates
                    :volatile t
                    :match 'identity


### PR DESCRIPTION
Helm seems to require that the `:requires-pattern` be an integer rather than anything non-nil.  This commit changes the argument from `t` to `1`, which should give exactly the intended functionality.

I did not track down whether this was caused by a new version of helm or of emacs.  All I tracked down is that there is a comparison with `t` that results in the error `(wrong-type-argument number-or-marker-p t)` when trying to do `C-c C-d`.