### PR TITLE
Clarifying the readme, and a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Building from Source
 When working on `lean-mode` itself, it is much easier to just `require` the sources than repeatedly building the MELPA packages:
 
 ```elisp
-(add-to-load-path "~/path/to/lean-mode/")
+(add-to-list 'load-path "~/path/to/lean-mode/")
+(require 'lean-mode)
 (require 'company-lean)
 (require 'helm-lean)
 ```

--- a/lean-flycheck.el
+++ b/lean-flycheck.el
@@ -82,7 +82,7 @@
                                             (lean-server-session-messages lean-server-session))))))))
 
 (defun lean-flycheck-init ()
-  "Initialize lean-flychek checker"
+  "Initialize lean-flycheck checker"
   (flycheck-define-generic-checker 'lean-checker
     "A Lean syntax checker."
     :start #'lean-flycheck-start


### PR DESCRIPTION
The `add-to-load-path` is a [spacemacs function](https://github.com/syl20bnr/spacemacs/blob/master/core/core-load-paths.el#L11), so it might be better to use the vanilla emacs function in the readme.

This commit also corrects a small typo in a function's document string.