### PR TITLE
chore: require lean-info in lean-type

### DIFF
--- a/lean-type.el
+++ b/lean-type.el
@@ -9,6 +9,7 @@
 (require 'dash)
 (require 'dash-functional)
 (require 's)
+(require 'lean-info)
 (require 'lean-util)
 (require 'lean-server)
 (require 'lean-debug)


### PR DESCRIPTION
This is also required for using gccemacs. It was meant to be in #30 but wasn't included for some reason. Sorry for the noise!