### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/company-lean.el
+++ b/company-lean.el
@@ -9,7 +9,7 @@
 ;; Maintainer: Sebastian Ullrich <sebasti@nullri.ch>
 ;; Created: Jan 09, 2014
 ;; Keywords: languages
-;; Package-Requires: ((emacs "24.3") (dash "2.12.0") (dash-functional "1.2.0") (s "1.10.0") (f "0.19.0") (company "0.9.3") (lean-mode "3.3.0"))
+;; Package-Requires: ((emacs "24.3") (dash "2.18.0") (s "1.10.0") (f "0.19.0") (company "0.9.3") (lean-mode "3.3.0"))
 ;; URL: https://github.com/leanprover/lean-mode
 
 ;; Released under Apache 2.0 license as described in the file LICENSE.
@@ -23,7 +23,6 @@
 (require 'company)
 (require 'company-etags)
 (require 'dash)
-(require 'dash-functional)
 (require 'f)
 (require 's)
 (require 'cl-lib)

--- a/helm-lean.el
+++ b/helm-lean.el
@@ -9,7 +9,7 @@
 ;; Maintainer: Sebastian Ullrich <sebasti@nullri.ch>
 ;; Created: Jan 09, 2014
 ;; Keywords: languages
-;; Package-Requires: ((emacs "24.3") (dash "2.12.0") (helm "2.8.0") (lean-mode "3.3.0"))
+;; Package-Requires: ((emacs "24.3") (dash "2.18.0") (helm "2.8.0") (lean-mode "3.3.0"))
 ;; URL: https://github.com/leanprover/lean-mode
 
 ;; Released under Apache 2.0 license as described in the file LICENSE.

--- a/lean-mode.el
+++ b/lean-mode.el
@@ -10,7 +10,7 @@
 ;; Maintainer: Sebastian Ullrich <sebasti@nullri.ch>
 ;; Created: Jan 09, 2014
 ;; Keywords: languages
-;; Package-Requires: ((emacs "24.3") (dash "2.12.0") (dash-functional "1.2.0") (s "1.10.0") (f "0.19.0") (flycheck "30"))
+;; Package-Requires: ((emacs "24.3") (dash "2.18.0") (s "1.10.0") (f "0.19.0") (flycheck "30"))
 ;; URL: https://github.com/leanprover/lean-mode
 
 ;; Released under Apache 2.0 license as described in the file LICENSE.

--- a/lean-type.el
+++ b/lean-type.el
@@ -7,7 +7,6 @@
 
 (require 'cl-lib)
 (require 'dash)
-(require 'dash-functional)
 (require 's)
 (require 'lean-info)
 (require 'lean-util)

--- a/lean-util.el
+++ b/lean-util.el
@@ -8,7 +8,6 @@
 (require 'f)
 (require 's)
 (require 'dash)
-(require 'dash-functional)
 
 (defun lean-setup-rootdir ()
   (let ((root (executable-find lean-executable-name)))


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218