### PR TITLE
feat(*): port to eldoc handling of emacs 28

### DIFF
--- a/lean-mode.el
+++ b/lean-mode.el
@@ -188,8 +188,13 @@ enabled and disabled respectively.")
   (lean-ensure-info-buffer lean-show-goal-buffer-name)
   ;; eldoc
   (when lean-eldoc-use
-    (set (make-local-variable 'eldoc-documentation-function)
-         'lean-eldoc-documentation-function)
+    (cond ((<= emacs-major-version 27)
+           (set (make-local-variable 'eldoc-documentation-function)
+                'lean-eldoc-documentation-function))
+          (t (add-hook 'eldoc-documentation-functions
+                       #'lean-eldoc-documentation-function nil t)
+             (setq-local eldoc-documentation-strategy
+                         'eldoc-documentation-default)))
     (eldoc-mode t)))
 
 ;; Automode List


### PR DESCRIPTION
Closes #33.

Some things of note:

 - I had to create `lean-add-to-kill-ring` as a local variable because the new eldoc abstracts direct interaction with the documentation functions so (I think) it is not possible to directly pass this as a variable to the documentation function.
 - Also, by `(eldoc-print-current-symbol-info t)` being (I think) the only way of calling the documentation functions, for some reason this always shows the docs in a separate buffer. Even when I open a lisp file and run this function the same happens, so just a quirk of the newer eldoc.

Works as of testing this on emacs 27.2 and 28.0.50 by moving the cursor over a name as well as by triggering the menu option "Show type info" and seeing whether the kill-ring is affected by the setting of the option `lean-show-type-add-to-kill-ring`.