### PR TITLE
Abbreviations `\/` and `\quot` for `⧸`

### DIFF
--- a/lean-input.el
+++ b/lean-input.el
@@ -635,7 +635,9 @@ order for the change to take effect."
                                                ⍉⍊⍋⍌⍍⍎⍏⍐⍑⍒⍓⍔⍕⍖⍗⍘⍙⍚⍛
                                                ⍜⍝⍞⍟⍠⍡⍢⍣⍤⍥⍦⍧⍨⍩⍪⍫⍬⍭⍮
                                                ⍯⍰⍱⍲⍳⍴⍵⍶⍷⍸⍹⍺⎕"))
-
+  ("/"         . ("⧸"))
+  ("quot"      . ("⧸"))
+                                      
   ;; Some combining characters.
   ;;
   ;; The following combining characters also have (other)


### PR DESCRIPTION
[Mathlib PR 10501](https://github.com/leanprover-community/mathlib/pull/10501) introduces `⧸` as an infix operator producing quotient types. I propose that we use `\/` and `\quot` as abbreviations for this operator.

 * [VS Code PR](https://github.com/leanprover/vscode-lean/pull/284)